### PR TITLE
🛟 Arrumador: Configure mise and autorelease pipeline

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,70 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+jobs:
+  autorelease:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup OS dependencies
+        run: sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev cmake make
+
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+        with:
+          install: true
+
+      - name: Install
+        run: mise run install
+
+      - name: Codegen
+        run: mise run codegen
+
+      - name: PR if Difference
+        id: check_changes
+        run: |
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "Changes detected after codegen. Creating PR..."
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git checkout -b auto-codegen-${GITHUB_SHA::7}
+            git commit -am "chore: update codegen artifacts"
+            git push origin auto-codegen-${GITHUB_SHA::7} || true
+            gh pr create --title "chore: update codegen artifacts" --body "Automated PR to update codegen artifacts." --base ${GITHUB_REF#refs/heads/} --head auto-codegen-${GITHUB_SHA::7} || true
+          else
+            echo "No changes detected after codegen."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: CI
+        run: mise run ci
+
+      - name: Release
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          gh release create ${GITHUB_REF#refs/tags/} --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Artifacts
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-artifacts
+          path: main

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -40,10 +40,10 @@ jobs:
             echo "Changes detected after codegen. Creating PR..."
             git config --global user.name "github-actions[bot]"
             git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git checkout -b auto-codegen-${GITHUB_SHA::7}
+            git checkout -b "auto-codegen-${GITHUB_SHA::7}"
             git commit -am "chore: update codegen artifacts"
-            git push origin auto-codegen-${GITHUB_SHA::7} || true
-            gh pr create --title "chore: update codegen artifacts" --body "Automated PR to update codegen artifacts." --base ${GITHUB_REF#refs/heads/} --head auto-codegen-${GITHUB_SHA::7} || true
+            git push origin "auto-codegen-${GITHUB_SHA::7}" || true
+            gh pr create --title "chore: update codegen artifacts" --body "Automated PR to update codegen artifacts." --base "${GITHUB_REF#refs/heads/}" --head "auto-codegen-${GITHUB_SHA::7}" || true
           else
             echo "No changes detected after codegen."
           fi
@@ -57,7 +57,7 @@ jobs:
       - name: Release
         if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
         run: |
-          gh release create ${GITHUB_REF#refs/tags/} --generate-notes
+          gh release create "${GITHUB_REF#refs/tags/}" --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,29 @@
+[tools]
+"github:lucasew/workspaced" = "0.1.6"
+
+[tasks.lint]
+run = "workspaced codebase lint"
+
+[tasks.fmt]
+run = "workspaced codebase format"
+
+[tasks.test]
+depends = ["test:*"]
+
+[tasks."test:build"]
+run = "cmake . && make"
+
+[tasks.codegen]
+depends = ["codegen:*"]
+
+[tasks."codegen:dummy"]
+run = "echo 'No codegen needed'"
+
+[tasks.install]
+depends = ["install:*"]
+
+[tasks."install:dummy"]
+run = "echo 'No install needed'"
+
+[tasks.ci]
+depends = ["lint", "test"]


### PR DESCRIPTION
**Assumptions**
- The project is a standard C application that builds using CMake, requiring `cmake`, `make`, and OpenGL dev dependencies (`libgl1-mesa-dev`, `libglu1-mesa-dev`, `freeglut3-dev`) installed on the GitHub Actions runner.
- The `autorelease` flow requires standard GitHub tokens for PRs and releases.
- "No install needed" and "No codegen needed" dummy tasks are safe defaults when a project has no specific codegen scripts or language-specific package manager install tasks.

**Alternatives Not Chosen**
- Using arbitrary linters directly in GitHub actions. We strictly used `workspaced` via `mise` as instructed.
- Creating separate workflow files for release vs PRs. We consolidated everything into `.github/workflows/autorelease.yml` per the constraints.

**How To Pivot**
- To change the build command, edit the `run` property of `[tasks."test:build"]` in `mise.toml`.
- To modify linting/formatting rules, configure `workspaced` settings according to its documentation, but keep the `mise` entrypoint intact.

**Next Knobs**
- Update the version of `lucasew/workspaced` in `mise.toml` when a new version is released.
- Add specific `codegen:*` tasks in `mise.toml` if the project later introduces code generation.

---
*PR created automatically by Jules for task [662975285028538861](https://jules.google.com/task/662975285028538861) started by @lucasew*