### PR TITLE
🛡️ Sentinel: [Medium] Fix ignored errors and assert side effects

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2026-03-16: Medium - Unchecked allocations and asserts with side-effects that get compiled out in release builds, fixed by introducing centralized error reporting.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(gl_blasteroids C)
 
-add_executable(main main.c asteroid.c constants.c bullet.c point.c math_utils.c color.c spaceship.c object.c object_list.c)
+add_executable(main main.c asteroid.c constants.c bullet.c point.c math_utils.c color.c spaceship.c object.c object_list.c error_reporter.c)
 
 IF (WIN32)
     target_link_libraries(main glut32 opengl32 glu32 m)

--- a/bullet.c
+++ b/bullet.c
@@ -12,11 +12,15 @@
 #include "object.h"
 #include "spaceship.h"
 #include "constants.h"
+#include "error_reporter.h"
 
 
 Bullet_t* gb_Bullet__new(Point_t position, Color_t color, float speed, float heading, float power) {
    Bullet_t* ret = calloc(1, sizeof(Bullet_t));
-   assert(ret);
+   if (!ret) {
+       report_error("Failed to allocate Bullet_t");
+       exit(1);
+   }
    ret->color = color;
    ret->position = position;
    ret->heading = heading;

--- a/constants.h
+++ b/constants.h
@@ -18,11 +18,11 @@ extern int SCREEN_HEIGHT;
 /**
  * Atualizações de estado por segundo
  */
-int FPS;
+extern int FPS;
 
 /**
  * Tempo de cada frame, delay usado entre cada iteração do jogo.
  */
-float tick_size;
+extern float tick_size;
 
 #endif //GL_BLASTEROIDS_CONSTANTS_H

--- a/error_reporter.c
+++ b/error_reporter.c
@@ -1,0 +1,8 @@
+#include "error_reporter.h"
+#include <stdio.h>
+
+void report_error(const char *message) {
+    if (message) {
+        fprintf(stderr, "Error: %s\n", message);
+    }
+}

--- a/error_reporter.h
+++ b/error_reporter.h
@@ -1,0 +1,6 @@
+#ifndef ERROR_REPORTER_H
+#define ERROR_REPORTER_H
+
+void report_error(const char *message);
+
+#endif // ERROR_REPORTER_H

--- a/main.c
+++ b/main.c
@@ -13,6 +13,7 @@
 #include "asteroid.h"
 #include "bullet.h"
 #include "main.h"
+#include "error_reporter.h"
 
 
 pthread_mutex_t lock;
@@ -137,7 +138,10 @@ void gb_unlock() {
  */
 int main(int argc, char **argv) {
     srand(time(NULL)); // Adicionando bagunça nisso
-    assert(!pthread_mutex_init(&lock, NULL));
+    if (pthread_mutex_init(&lock, NULL) != 0) {
+        report_error("Failed to initialize mutex");
+        exit(1);
+    }
     elements = gb_ObjectList__new();
     spaceship = gb_Spaceship__new_random();
     spaceship->position.x = 200;

--- a/object_list.c
+++ b/object_list.c
@@ -8,9 +8,14 @@
 
 #include "object_list.h"
 #include "bullet.h"
+#include "error_reporter.h"
 
 ObjectList_t **gb_ObjectList__new() {
     ObjectList_t ** ret = malloc(sizeof(ObjectList_t*));
+    if (!ret) {
+        report_error("Failed to allocate ObjectList pointer array");
+        exit(1);
+    }
     *ret = NULL;
     return ret;
 }
@@ -23,10 +28,16 @@ int gb_ObjectList__push(ObjectList_t **this, Packet_t pkt) {
             .this = calloc(1, sizeof(Packet_t)),
             .next = NULL
     };
-    assert(toadd.this);
+    if (!toadd.this) {
+        report_error("Failed to allocate Packet_t");
+        exit(1);
+    }
     *toadd.this = pkt;
     ObjectList_t* toaddptr = calloc(1, sizeof(ObjectList_t));
-    assert(toaddptr);
+    if (!toaddptr) {
+        report_error("Failed to allocate ObjectList_t");
+        exit(1);
+    }
     *toaddptr = toadd;
     toaddptr->next = *this;
     *this = toaddptr;
@@ -70,7 +81,10 @@ int gb_ObjectList__check_collision(ObjectList_t **this) {
     }
     int collisions = 0;
     ObjectList_t *dummy = *this;
-    assert(dummy != NULL);
+    if (dummy == NULL) {
+        report_error("dummy in check_collision is NULL");
+        return 0;
+    }
     int i = 0;
     for (ObjectList_t *inner = dummy; inner != NULL; inner = inner->next) {
         int j = 0;

--- a/spaceship.h
+++ b/spaceship.h
@@ -94,7 +94,7 @@ void gb_Spaceship__destroy(Spaceship_t **ship);
  */
 void gb_Spaceship__draw(Spaceship_t *ship);
 
-Methods_t spaceship_methods;
+extern Methods_t spaceship_methods;
 /**
  * Encapsula o objeto nave em um objeto pacote, gambiarra de interface
  * @param obj Objeto nave a ser encapsulado


### PR DESCRIPTION
### Severity: Medium
### Vulnerability
The codebase previously swallowed memory allocation failures or mutex initialization errors when compiled in release mode. The usage of `assert(ptr)` or `assert(side_effect())` meant that in release builds (with `NDEBUG` defined), critical initialization like `pthread_mutex_init()` was completely omitted, causing undefined behavior and race conditions. Furthermore, missing `extern` declarations caused linker errors on modern GCC due to `-fno-common`.

### Impact
Without proper error handling, the game could silently fail to initialize the game state lock or segfault on memory exhaustion without a trace.

### Fix
1. Implemented a centralized `report_error` function as required by global directives.
2. Replaced `assert()` calls with explicit null checks that call `report_error` and exit securely with status `1`.
3. Moved the mutex initialization out of the `assert` macro.
4. Added `extern` specifiers to global variables defined in headers to fix linker issues.
5. Logged the pattern in the `.jules/sentinel.md` journal.

### Verification
- `cmake . && make` passes without linker errors.
- Verified that all replaced asserts correctly print using the centralized error reporter and fail securely.

### Assumptions
- The application is a standalone executable and can safely use `exit(1)` when out-of-memory or failing to initialize a critical mutex.
- A basic `fprintf(stderr, ...)` centralized reporter is sufficient given no external error logging service like Sentry is currently configured in this C project.

### Alternatives Not Chosen
- Adding `if (!ptr) { ... }` everywhere without a central reporter. Rejected because it violates the "Centralized Error Reporting" global directive.
- Fixing only the mutex assert. Rejected because memory allocations in C also need secure failure paths, and fixing both fits well within the 260 lines limit.

### How To Pivot
- If a custom crash handler or different logging backend (e.g. Syslog) is preferred, simply update `report_error` in `error_reporter.c`.
- If memory allocations should return `NULL` to the caller instead of crashing, the checks in `gb_ObjectList__new` etc can be modified to return `NULL` or error codes instead of calling `exit(1)`.

### Next Knobs
- `error_reporter.c`: The central place to change the error output format or destination.
- `CMakeLists.txt`: If the project switches to another build system, `error_reporter.c` must be included.

---
*PR created automatically by Jules for task [12053780911688860777](https://jules.google.com/task/12053780911688860777) started by @lucasew*